### PR TITLE
feat: Add GitHub Action to build Docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: make build-image


### PR DESCRIPTION
Adds a GitHub Action that builds the Docker image for the node application. The workflow is triggered on push and pull request to the main branch. It uses the 'make build-image' command to build the image.